### PR TITLE
[v1.5] Formally Add leftJoin

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,8 +97,9 @@ print("The book's name is " + book['name'])
 | int | [insertBatch(table, rows{})](#insertbatchtable-rows) |
 | int | [update(table, row{}, condition[])](#updatetable-row-condition) |
 | int | [insertOrUpdate(table, row{}, key)](#insertorupdatetable-row-key) |
-| namedtuple | [getOne(table, fields[], where[], order[], limit[])](#getonetable-fields-where-order-limit) |
-| namedtuple[] | [getAll(table, fields[], where[], order[], limit[]))](#getalltable-fields-where-order-limit) |
+| dict | [getOne(table, fields[], where[], order[], limit[])](#getonetable-fields-where-order-limit) |
+| dict[] | [getAll(table, fields[], where[], order[], limit[]))](#getalltable-fields-where-order-limit) |
+| dict[] | [leftJoin(tables(2), fields(), join_fields(2), where=[], order=[], limit=[])](#leftJointables2-fields-join_fields2-where-order-limit) |
 | int | [delete(table, fields[], condition[], order[], limit[])](#deletetable-fields-condition-order-limit) |
 | int | [lastId()](#lastid) |
 | str | [lastQuery()](#lastquery) |
@@ -154,7 +155,7 @@ db.insertOrUpdate("books",
 ```
 
 ## getOne(table, fields[], where[], order[], limit[])
-Get a single record from a table given a condition (or no condition). The resultant row is returned as a single namedtuple. `None` is returned if no record can be found.
+Get a single record from a table given a condition (or no condition). The resultant row is returned as a single dictionary. `None` is returned if no record can be found.
 
 ```python
 book = db.getOne("books", ["id", "name"])
@@ -168,7 +169,7 @@ book = db.getOne("books", ["name", "year"], ("id=1"))
 ```
 
 ## getAll(table, fields[], where[], order[], limit[])
-Get multiple records from a table given a condition (or no condition). The resultant rows are returned as a list of namedtuples. `None` is returned if no record(s) can be found.
+Get multiple records from a table given a condition (or no condition). The resultant rows are returned as a list of dictionaries. `None` is returned if no record(s) can be found.
 
 ```python
 # get multiple rows based on a parametrized condition
@@ -190,6 +191,26 @@ books = db.getAll("books",
 	["year", "DESC"],	# ORDER BY year DESC for descending (ASC for ascending)
 	[0, 10]			# LIMIT 0, 10
 )
+```
+
+## leftJoin(tables(2), fields()[], join_fields(2), where=[], order=[], limit=[])
+Get multiple records, for multiple fields, spanning two tables, given a condition (or no condition) for the first table and two joining fields that would share the same value between tables. The resultant rows are returned as a list of dictionaries. `None` is returned if no record(s) can be found.
+
+```python
+# get multiple records for multiple fields spanning two tables that share a common field, based on a parametrized condition
+book_sales = db.leftJoin(
+    ("books", "transactions"),
+    (
+        ["edition"], # "books" fields
+        ["fname", "date"] # "transactions" fields
+    ),
+    ("id", "book_id"), # same id number in both tables
+    ("name=%s", [book_name])
+)
+
+print("All sales that match book name:\n")
+for sale in book_sales:
+	print(f"{sale['fname']} purchased {sale['edition']} edition on {sale['date']}")
 ```
 
 ## delete(table, fields[], condition[], order[], limit[])

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 
 setup(
 	name="simplemysql",
-	version="1.4",
+	version="1.5",
 	description="An ultra simple wrapper for Python MySQLdb with very basic functionality",
 	author="Kailash Nadh, David Wolfe",
 	author_email="rehlmgaming@gmail.com",

--- a/simplemysql/simplemysql.py
+++ b/simplemysql/simplemysql.py
@@ -30,7 +30,6 @@
 """
 
 import mysql.connector as mysql
-from collections import namedtuple
 from itertools import repeat
 
 
@@ -140,8 +139,8 @@ class SimpleMysql:
 
         rows = None
         if result:
-            Row = namedtuple("Row", [f[0] for f in cur.description])
-            rows = [Row(*r) for r in result]
+            fields = [f[0] for f in cur.description]
+            rows = [dict(zip(fields, r)) for r in result]
 
         return rows
 


### PR DESCRIPTION
- Formally add `leftJoin(tables(2), fields(), join_fields(2), where=[], order=[], limit=[])` to the README.
- Remove namedtuple dependency to make leftJoin consistent with the other function return types.
- Fixed README typos for getOne and getAll that claimed they returned namedtuples when they actually returned dictionaries.